### PR TITLE
Provide aliases for CLI scripts

### DIFF
--- a/doc/source/usage/cli.rst
+++ b/doc/source/usage/cli.rst
@@ -2,18 +2,16 @@ Command Line Interface
 ======================
 
 Command line interfaces (CLI) are provided for the two most common tasks:
-conformer generation and fingerprinting. At the moment, using the CLI requires
-:ref:`downloading the E3FP source <install:Option 3: Install from source>`.
-
-In the below examples, we assume the E3FP repository is located at
-``$E3FP_REPO``.
+conformer generation and fingerprinting.
+When e3fp is installed, the CLI commands are available as ``e3fp-conformer`` and
+``e3fp-fingerprint``.
 
 Conformer Generation CLI
 ------------------------
 
 To see all available options, run
 
-.. command-output:: python $E3FP_REPO/src/e3fp/conformer/generate.py --help
+.. command-output:: e3fp-conformer --help
    :shell:
 
 We will generate conformers for the molecule whose SMILES string is defined in
@@ -26,7 +24,7 @@ The below example generates at most 3 conformers for this molecule.
 
 .. code-block:: shell-session
 
-    $ python $E3FP_REPO/src/e3fp/conformer/generate.py -s caffeine.smi --num_conf 3 -o ./
+    $ e3fp-conformer -s caffeine.smi --num_conf 3 -o ./
     2017-07-17 00:11:05,743|WARNING|Only 1 processes available. 'mpi' mode not available.
     2017-07-17 00:11:05,748|INFO|num_proc is not specified. 'processes' mode will use all 8 processes
     2017-07-17 00:11:05,748|INFO|Parallelizer initialized with mode 'processes' and 8 processors.
@@ -54,14 +52,14 @@ Fingerprinting CLI
 
 To see all available options, run
 
-.. command-output:: python $E3FP_REPO/src/e3fp/fingerprint/generate.py --help
+.. command-output:: e3fp-fingerprint --help
    :shell:
 
 To continue the above example, we will fingerprint our caffeine conformers.
 
 .. code-block:: shell-session
 
-    $ python $E3FP_REPO/src/e3fp/fingerprint/generate.py caffeine.sdf.bz2 --bits 1024
+    $ e3fp-fingerprint caffeine.sdf.bz2 --bits 1024
     2017-07-17 00:12:33,797|WARNING|Only 1 processes available. 'mpi' mode not available.
     2017-07-17 00:12:33,801|INFO|num_proc is not specified. 'processes' mode will use all 8 processes
     2017-07-17 00:12:33,801|INFO|Parallelizer initialized with mode 'processes' and 8 processors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,10 @@ dev = [
 Homepage = "https://github.com/keiserlab/e3fp"
 Download = "https://github.com/keiserlab/e3fp/tarball/{version}"
 
+[project.scripts]
+e3fp-fingerprint = "e3fp.fingerprint.generate:main"
+e3fp-conformer = "e3fp.conformer.generate:main"
+
 [tool.pytest.ini_options]
 addopts = "-ra -q"
 testpaths = ["e3fp/test"]

--- a/src/e3fp/conformer/generate.py
+++ b/src/e3fp/conformer/generate.py
@@ -446,7 +446,7 @@ def run(
         hdf5_buffer.close()
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(
         "Generate conformers from mol2 or SMILES",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -599,3 +599,7 @@ if __name__ == "__main__":
 
     kwargs = dict(params._get_kwargs())
     run(**kwargs)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/e3fp/fingerprint/generate.py
+++ b/src/e3fp/fingerprint/generate.py
@@ -374,7 +374,7 @@ def run(
         list(results_iter)
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(
         """Generate E3FP fingerprints from SDF files.""",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -512,3 +512,7 @@ if __name__ == "__main__":
     kwargs = dict(params._get_kwargs())
     sdf_files = kwargs.pop("sdf_files")
     run(sdf_files, **kwargs)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR aliases `src/e3fp/conformer/generate.py` as a command `e3fp-conformer` and `src/e3fp/fingerprint/generate.py` as a command `e3fp-fingerprint`, both added to the user's path. This allows the scripts to be used just by installing e3fp into an environment without needing to work with the source code.

Fixes #15 