### PR TITLE
Support unnamed molecules

### DIFF
--- a/doc/source/usage/config.rst
+++ b/doc/source/usage/config.rst
@@ -12,7 +12,7 @@ Loading Default Parameters
 The below example shows all default parameters, accessed via the
 :py:mod:`e3fp.config` module.
 
-.. literalinclude:: ../../../e3fp/config/defaults.cfg
+.. literalinclude:: ../../../src/e3fp/config/defaults.cfg
    :caption: `defaults.cfg <https://github.com/keiserlab/e3fp/blob/master/e3fp/config/defaults.cfg>`_
 
 :py:mod:`configparser` is used internally to parse and store these

--- a/src/e3fp/conformer/generate.py
+++ b/src/e3fp/conformer/generate.py
@@ -120,14 +120,19 @@ def generate_conformers(
         conformations generated, and 2D numpy array of pairwise RMSDs between
         final conformations.
     """
-    if name is None:
+    if name is None and input_mol.HasProp("_Name"):
         name = input_mol.GetProp("_Name")
+        log_name = name
+    else:
+        log_name = "molecule"
 
     if standardise:
         input_mol = mol_to_standardised_mol(input_mol)
 
     if save:
         if out_file is None:
+            if name is None:
+                raise ValueError("Molecule is missing property '_Name', cannot save conformers.")
             extensions = ("", ".gz", ".bz2")
             if compress not in (0, 1, 2):
                 compress = 0
@@ -139,7 +144,7 @@ def generate_conformers(
             logging.warning("{} already exists. Skipping.".format(out_file))
             return False
 
-    logging.info("Generating conformers for {}.".format(name))
+    logging.info("Generating conformers for {}.".format(log_name))
     try:
         conf_gen = ConformerGenerator(
             num_conf=num_conf,
@@ -154,12 +159,12 @@ def generate_conformers(
         mol, values = conf_gen.generate_conformers(input_mol)
         logging.info(
             "Generated {:d} conformers for {}.".format(
-                mol.GetNumConformers(), name
+                mol.GetNumConformers(), log_name
             )
         )
     except Exception:
         logging.warning(
-            "Problem generating conformers for {}.".format(name), exc_info=True
+            "Problem generating conformers for {}.".format(log_name), exc_info=True
         )
         return False
 
@@ -167,12 +172,12 @@ def generate_conformers(
         try:
             mol_to_sdf(mol, out_file)
             logging.info(
-                "Saved conformers for {} to {}.".format(name, out_file)
+                "Saved conformers for {} to {}.".format(log_name, out_file)
             )
         except Exception:
             logging.warning(
                 "Problem saving conformers for {} to {}.".format(
-                    name, out_file
+                    log_name, out_file
                 ),
                 exc_info=True,
             )

--- a/src/e3fp/conformer/generator.py
+++ b/src/e3fp/conformer/generator.py
@@ -206,20 +206,19 @@ class ConformerGenerator(object):
         mol : RDKit Mol
             Molecule.
         """
-        logging.debug("Adding hydrogens for %s" % mol.GetProp("_Name"))
+        log_name = mol.GetProp("_Name") if mol.HasProp("_Name") else "molecule"
+        logging.debug("Adding hydrogens for %s" % log_name)
         mol = Chem.AddHs(mol)  # add hydrogens
-        logging.debug("Hydrogens added to %s" % mol.GetProp("_Name"))
-        logging.debug("Sanitizing mol for %s" % mol.GetProp("_Name"))
+        logging.debug("Hydrogens added to %s" % log_name)
+        logging.debug("Sanitizing mol for %s" % log_name)
         Chem.SanitizeMol(mol)
-        logging.debug("Mol sanitized for %s" % mol.GetProp("_Name"))
+        logging.debug("Mol sanitized for %s" % log_name)
         if self.max_conformers == -1 or type(self.max_conformers) is not int:
             self.max_conformers = self.get_num_conformers(mol)
         n_confs = self.max_conformers * self.pool_multiplier
         if self.first_conformers == -1:
             self.first_conformers = self.max_conformers
-        logging.debug(
-            "Embedding %d conformers for %s" % (n_confs, mol.GetProp("_Name"))
-        )
+        logging.debug("Embedding %d conformers for %s" % (n_confs, log_name))
         AllChem.EmbedMultipleConfs(
             mol,
             numConfs=n_confs,
@@ -228,7 +227,7 @@ class ConformerGenerator(object):
             randomSeed=self.seed,
             ignoreSmoothingFailures=True,
         )
-        logging.debug("Conformers embedded for %s" % mol.GetProp("_Name"))
+        logging.debug("Conformers embedded for %s" % log_name)
         return mol
 
     def get_molecule_force_field(self, mol, conf_id=None, **kwargs):
@@ -269,11 +268,12 @@ class ConformerGenerator(object):
         mol : RDKit Mol
             Molecule.
         """
-        logging.debug("Minimizing conformers for %s" % mol.GetProp("_Name"))
+        log_name = mol.GetProp("_Name") if mol.HasProp("_Name") else "molecule"
+        logging.debug("Minimizing conformers for %s" % log_name)
         for conf in mol.GetConformers():
             ff = self.get_molecule_force_field(mol, conf_id=conf.GetId())
             ff.Minimize()
-        logging.debug("Conformers minimized for %s" % mol.GetProp("_Name"))
+        logging.debug("Conformers minimized for %s" % log_name)
 
     def get_conformer_energies(self, mol):
         """Calculate conformer energies.
@@ -308,7 +308,8 @@ class ConformerGenerator(object):
         A new RDKit Mol containing the chosen conformers, sorted by
         increasing energy.
         """
-        logging.debug("Pruning conformers for %s" % mol.GetProp("_Name"))
+        log_name = mol.GetProp("_Name") if mol.HasProp("_Name") else "molecule"
+        logging.debug("Pruning conformers for %s" % log_name)
         energies = self.get_conformer_energies(mol)
         energy_below_threshold = np.ones_like(energies, dtype=np.bool_)
 
@@ -378,7 +379,7 @@ class ConformerGenerator(object):
             conf = mol.GetConformer(conf_ids[i])
             new.AddConformer(conf, assignId=True)
 
-        logging.debug("Conformers filtered for %s" % mol.GetProp("_Name"))
+        logging.debug("Conformers filtered for %s" % log_name)
         return new, np.asarray(accepted, dtype=int), energies, rmsds
 
     @staticmethod

--- a/src/e3fp/fingerprint/fprinter.py
+++ b/src/e3fp/fingerprint/fprinter.py
@@ -556,13 +556,15 @@ class ShellsGenerator(object):
             if i < j
         ]
         if len(overlap_atoms) > 0:
+            owning_mol = conf.GetOwningMol()
+            name = owning_mol.GetProp("_Name") if owning_mol.HasProp("_Name") else "molecule"
             logging.warning(
                 "Overlapping atoms {} in conformer {} of molecule"
                 " {}. Fingerprinting will continue but is less "
                 "reliable.".format(
                     ", ".join(map(repr, overlap_atoms)),
                     conf.GetId(),
-                    conf.GetOwningMol().GetProp("_Name"),
+                    name,
                 )
             )
 

--- a/src/e3fp/fingerprint/structs.py
+++ b/src/e3fp/fingerprint/structs.py
@@ -263,7 +263,8 @@ def shell_to_pdb(
     list of str: list of PDB file lines, if `out_file` not specified
     """
     remark = "REMARK 400"
-    header_lines = [remark + " COMPOUND", remark + " " + mol.GetProp("_Name")]
+    name = mol.GetProp("_Name") if mol.HasProp("_Name") else "molecule"
+    header_lines = [remark + " COMPOUND", remark + " " + name]
     lines = header_lines + [
         "MODEL",
     ]

--- a/tests/test_conformer.py
+++ b/tests/test_conformer.py
@@ -86,3 +86,14 @@ class TestConformer:
         sdf_files = [SDF_FILE_COMPRESSED, SDF_FILE_UNCOMPRESSED]
         smiles = [Chem.MolToSmiles(mol_from_sdf(f)) for f in sdf_files]
         assert smiles[0] == smiles[1]
+
+    def test_conformer_generation_without_name(self):
+        from e3fp.conformer.util import mol_from_smiles
+        from e3fp.conformer.generate import generate_conformers
+
+        confgen_params = {"num_conf": 1, "seed": 42}
+        smiles = "C" * 20  # long flexible molecule
+        mol = mol_from_smiles(smiles, "tmp")
+        mol.ClearProp("_Name")
+        assert not mol.HasProp("_Name")
+        generate_conformers(mol, **confgen_params)

--- a/tests/test_fingerprinting.py
+++ b/tests/test_fingerprinting.py
@@ -925,6 +925,17 @@ class TestGenerateFingerprint:
 
         assert fprints1 == fprints2
 
+    def test_fingerprint_generation_without_name(self):
+        from e3fp.fingerprint import fprinter
+        from e3fp.conformer.util import mol_from_sdf
+
+        mol = mol_from_sdf(PLANAR_SDF_FILE)
+        mol.ClearProp("_Name")
+        assert not mol.HasProp("_Name")
+        fpr = fprinter.Fingerprinter(level=5, bits=1024, stereo=True, radius_multiplier=1.718)
+        fpr.run(conf=0, mol=mol)
+        fpr.get_fingerprint_at_level(5)
+
 
 class TestAtomInvariant:
     def test_daylight_invariants(self):


### PR DESCRIPTION
As noted in #79, e3fp requires that molecules have the property `_Name` even if we don't need that. Since we only need that just for saving, this PR changes the behavior to throw an error if `_Name` is needed and otherwise to proceed as normal.