### PR TITLE
Include license file in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,0 @@
-include LICENSE.txt
-recursive-include e3fp/test/data *
-recursive-include e3fp *cfg
-recursive-include e3fp/fingerprint/metrics *
-recursive-exclude * __pycache__
-recursive-exclude * *.py[co] 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.rst"
 authors = [
     {name = "Seth Axen", email = "seth.axen@gmail.com"},
 ]
-license = {text = "LGPLv3"}
+license = {file = "LICENSE.txt"}
 keywords = ["e3fp", "3d", "molecule", "fingerprint", "conformer"]
 classifiers = [
     "Programming Language :: Python",


### PR DESCRIPTION
It seems that using the `pyproject.toml` our `MANIFEST.in` is being ignored. That's fine, it's outdated anyways (this PR removes it). But this does mean that `LICENSE.txt` was not being packaged with the source distribution, which the conda-forge recipe doesn't like (https://github.com/conda-forge/e3fp-feedstock/tree/main/recipe). By specifying the license by filename, it is now added to the source distribution.