### PR TITLE
Allow Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9", "3.13"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       uv_version: "0.5.2"
-      python_version: "3.12"
+      python_version: "3.13"
     steps:
       - uses: actions/checkout@v2
       - name: Setup MPI

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.12"
+    python: "3.13"
   commands:
     - asdf plugin add uv
     - asdf install uv latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "e3fp"
-version = "1.2.6"
-requires-python = ">=3.9, <3.13"
+version = "1.2.7"
+requires-python = ">=3.9, <3.14"
 description = "Molecular 3D fingerprinting"
 readme = "README.rst"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
     "Operating System :: OS Independent",
     "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,11 @@ testpaths = ["e3fp/test"]
 # https://github.com/astral-sh/uv/issues/6281
 [tool.uv]
 constraint-dependencies = ["numba>=0.60.0"]
+# Resolve dependencies separately for each Python version
+environments = [
+    "python_version>='3.13'",
+    "python_version=='3.12'",
+    "python_version=='3.11'",
+    "python_version=='3.10'",
+    "python_version=='3.9'",
+]

--- a/src/e3fp/__init__.py
+++ b/src/e3fp/__init__.py
@@ -1,4 +1,4 @@
 import importlib.metadata
 from .util import E3FPWarning, E3FPDeprecationWarning
 
-__version__ = importlib.metadata.version("e3fp")
+# __version__ = importlib.metadata.version("e3fp")

--- a/src/e3fp/__init__.py
+++ b/src/e3fp/__init__.py
@@ -1,4 +1,4 @@
 import importlib.metadata
 from .util import E3FPWarning, E3FPDeprecationWarning
 
-# __version__ = importlib.metadata.version("e3fp")
+__version__ = importlib.metadata.version("e3fp")

--- a/src/e3fp/fingerprint/db.py
+++ b/src/e3fp/fingerprint/db.py
@@ -105,9 +105,8 @@ class FingerprintDatabase(object):
 
     Alternatively, the underlying `scipy.sparse.csr_matrix` may be accessed.
 
-    >>> db.array
-    <3x1024 sparse matrix of type '<class 'numpy.bool'>'
-    ...with 327 stored elements in Compressed Sparse Row format>
+    >>> db.array  # doctest: +ELLIPSIS
+    <...sparse matrix...with 327 stored elements...>
     >>> db.array.toarray()
     array([[False, False, False, ..., False, False, False],
            [False, False, False, ..., False, False, False],


### PR DESCRIPTION
Allows Python 3.13 installation, fixes https://github.com/keiserlab/e3fp/issues/88. I ran tests locally and everything seems to be working.

I also changed the version to 1.2.7, since that would probably be the next release, but I can revert that one if necessary.